### PR TITLE
Set scan type Connect() as default.

### DIFF
--- a/ospd_nmap/wrapper.py
+++ b/ospd_nmap/wrapper.py
@@ -124,9 +124,9 @@ TIMING_ARGS = [
 ]
 
 SCANTYPE_ARGS = [
-    'SYN',
     'Connect()',
     'SYN',
+    'Connect()',
     'ACK',
     'FIN',
     'Window',


### PR DESCRIPTION
This allows to run a scan without root permissions.