### PR TITLE
Fix typo.

### DIFF
--- a/ospd_nmap/wrapper.py
+++ b/ospd_nmap/wrapper.py
@@ -31,7 +31,7 @@ import subprocess
 OSPD_DESC = """
 This scanner runs the tool 'nmap' to scan the target hosts.
 
-This tool is availble for most operating systems and identifies open ports,
+This tool is available for most operating systems and identifies open ports,
 probes the services, operating systems and even can run more sophisticated
 detection routines.
 


### PR DESCRIPTION
Fix typo found by [codespell](https://github.com/codespell-project/codespell) 1.14

```
codespell . -S ".git"
```